### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Create release
+on: [push]
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.8"
+
+    - name: Install Hatch
+      run: pipx install hatch
+
+    - name: Set variables
+      id: set_variables
+      run: |
+        tag="$(git describe --tags --abbrev=0)"
+        echo "::group::Variables"
+        cat << EOF | tee -a "$GITHUB_OUTPUT"
+        tag=${tag}
+        version=v$(hatch project metadata | jq -r .version)
+        EOF
+        echo "::endgroup::"
+
+    - name: Bundle and create release
+      env:
+        GH_TOKEN: ${{ github.token }}
+        tag: ${{ steps.set_variables.outputs.tag }}
+        version: ${{ steps.set_variables.outputs.version }}
+      if: |
+        env.tag != env.version
+      run: |
+        project_name="$(hatch project metadata | jq -r .name)"
+        sources="$(\
+          hatch run default:pip list --verbose --format json \
+          | jq -r '.[] | select(.editable_project_location == null) | "\(.name);\(.location)"' \
+        )"
+
+        echo "::group::Dependencies"
+        printf '%s\n' "${sources}"
+        echo "::endgroup::"
+
+        mkdir bundle/
+        cp -r yt_dlp_plugins bundle/
+
+        while IFS=';' read -r name path; do
+          if [[ ! "${name}" =~ ^(pip|setuptools|wheel)$ ]]; then
+            package_name="$(tr '[:upper:]' '[:lower:]' <<<"${name}" | sed 's/-/_/g')"
+            cp -r "${path}/${package_name}" bundle/
+          fi
+        done <<<"${sources}"
+
+        cd bundle/
+        find . -type f -name '*.py[co]' -delete -o -type d -name __pycache__ -delete
+        zip -9 --recurse-paths "${project_name}" *
+        gh release create "${version}" --latest \
+          --title "${project_name} ${version}" \
+          "${project_name}.zip"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This repository contains a sample plugin package for [yt-dlp](https://github.com/yt-dlp/yt-dlp#readme). 
+This repository contains a sample plugin package for [yt-dlp](https://github.com/yt-dlp/yt-dlp#readme).
 
 See [yt-dlp plugins](https://github.com/yt-dlp/yt-dlp#plugins) for more details.
 
@@ -18,3 +18,28 @@ See [installing yt-dlp plugins](https://github.com/yt-dlp/yt-dlp#installing-plug
 ## Development
 
 See the [Plugin Development](https://github.com/yt-dlp/yt-dlp/wiki/Plugin-Development) section of the yt-dlp wiki.
+Add required dependencies to the `dependencies` section in the `pyproject.toml`.
+From within the plugin, use an import pattern similar to the following:
+```py
+import sys
+import pathlib
+
+
+import_path = str(pathlib.Path(__file__).parent.parent.parent)
+
+sys.path.insert(0, import_path)
+try:
+	import some_dependency
+
+except ImportError:
+	some_dependency = None
+
+finally:
+	sys.path.remove(import_path)
+```
+
+## Release
+
+To create a release, simply increment the version in the `pyproject.toml` file.
+While convenient, conditional requirements or non pure python modules will most likely not work.
+Please edit the `.github/workflows/release.yml` accordingly if you require more control.

--- a/README.md
+++ b/README.md
@@ -7,13 +7,32 @@ See [yt-dlp plugins](https://github.com/yt-dlp/yt-dlp#plugins) for more details.
 
 Requires yt-dlp `2023.01.02` or above.
 
+### Install with pip
+
 You can install this package with pip:
 ```
 python3 -m pip install -U https://github.com/yt-dlp/yt-dlp-sample-plugins/archive/master.zip
 ```
 
-See [installing yt-dlp plugins](https://github.com/yt-dlp/yt-dlp#installing-plugins) for the other methods this plugin package can be installed.
+### Install manually
 
+1. Download the latest release zip from [releases](https://github.com/yt-dlp/yt-dlp-sample-plugins/releases) 
+
+2. Add the zip to one of the [yt-dlp plugin locations](https://github.com/yt-dlp/yt-dlp#installing-plugins)
+
+    - User Plugins
+        - `${XDG_CONFIG_HOME}/yt-dlp/plugins` (recommended on Linux/MacOS)
+        - `~/.yt-dlp/plugins/`
+        - `${APPDATA}/yt-dlp/plugins/` (recommended on Windows)
+    
+    - System Plugins
+       -  `/etc/yt-dlp/plugins/`
+       -  `/etc/yt-dlp-plugins/`
+    
+    - Executable location
+        - Binary: where `<root-dir>/yt-dlp.exe`, `<root-dir>/yt-dlp-plugins/`
+
+For more locations and methods, see [installing yt-dlp plugins](https://github.com/yt-dlp/yt-dlp#installing-plugins) 
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,18 @@ For more locations and methods, see [installing yt-dlp plugins](https://github.c
 ## Development
 
 See the [Plugin Development](https://github.com/yt-dlp/yt-dlp/wiki/Plugin-Development) section of the yt-dlp wiki.
+
+### Dependencies
+
 Add required dependencies to the `dependencies` section in the `pyproject.toml`.
-From within the plugin, use an import pattern similar to the following:
+
+#### Bundling with release zip
+
+By default, the [release action](.github/workflows/release.yml) will try to bundle the dependencies in the release zip. 
+For these dependencies to work, they must be pure python modules.
+ 
+From within the plugin, you will also need to use an import pattern similar to the following:
+
 ```py
 import sys
 import pathlib
@@ -46,7 +56,7 @@ import pathlib
 
 import_path = str(pathlib.Path(__file__).parent.parent.parent)
 
-sys.path.insert(0, import_path)
+sys.path.append(0, import_path)
 try:
 	import some_dependency
 
@@ -56,6 +66,8 @@ except ImportError:
 finally:
 	sys.path.remove(import_path)
 ```
+
+If you do not want to bundle the dependencies with the release zip, you can add the dependencies to the exclusion list in the [release action](.github/workflows/release.yml).
 
 ## Release
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ import pathlib
 
 import_path = str(pathlib.Path(__file__).parent.parent.parent)
 
-sys.path.append(0, import_path)
+sys.path.append(import_path)
 try:
 	import some_dependency
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,22 @@
 [build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.distutils.bdist_wheel]
-universal = true
+[project]
+name = "yt-dlp-sample-plugins"
+version = "2023.01.02"
+readme = "README.md"
+requires-python = ">=3.8"
+license = "MIT"
+keywords = ["yt-dlp", "yt-dlp-plugin"]
+authors = [
+  { name = "John Doe", email = "johndoe@example.com" },
+]
+dependencies = []
+
+[tool.hatch.env.default]
+installer = "uv"
+path = ".venv"
+
+[tool.hatch.build.targets.wheel]
+packages = ["yt_dlp_plugins"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "yt-dlp-sample-plugins"
 version = "2023.01.02"
 readme = "README.md"
 requires-python = ">=3.8"
-license = "MIT"
+license = {file = "LICENSE"}
 keywords = ["yt-dlp", "yt-dlp-plugin"]
 authors = [
   { name = "John Doe", email = "johndoe@example.com" },

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,0 @@
-[metadata]
-name = yt-dlp-sample-plugins
-version = 2023.01.01
-
-[options]
-packages = find_namespace:


### PR DESCRIPTION
Following changes:
- Migrates plugin to hatch for easy access to metadata and consistency with main project
- Support for automated release workflow
- Support for automated™ plugin bundling
- Readme adjustments to reflect changes
  - In the future, the import should be moved to plugin systems responsibility
  
Upon merge this will create a dummy release if actions are activated. The same goes for when creating a repository with this as template, and actions enabled. Is this a problem?

Demo release: <https://github.com/Grub4K/yt-dlp-sample-plugins/releases/tag/v2023.1.2>

Fixes #2